### PR TITLE
🪶 Add support for reflection so we can get the `tg_size`

### DIFF
--- a/bindings_generator/src/main.rs
+++ b/bindings_generator/src/main.rs
@@ -5,10 +5,7 @@ fn main() {
 
     bindgen::Builder::default()
         .header(header)
-        .clang_args(&[
-            "-I./vendor/",
-            "-Wno-microsoft-enum-forward-reference"
-        ])
+        .clang_args(&["-I./vendor/", "-Wno-microsoft-enum-forward-reference"])
         .dynamic_link_require_all(true)
         .dynamic_library_name("metal_irconverter")
         .layout_tests(false)
@@ -28,7 +25,6 @@ fn main() {
         .blocklist_item("__security_cookie")
         .blocklist_item("__va_start")
         .blocklist_item("__report_gsfailure")
-
         // Not in the DLLs provided by Apple
         .blocklist_item("IRMetalLibSynthesizeIntersectionWrapperFunction")
         .generate()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
 use saxaboom::{
-    IRComparisonFunction, IRCompiler, IRFilter, IRMetalLibBinary, IRObject, IRRootConstants,
-    IRRootDescriptor1, IRRootParameter1, IRRootParameter1_u, IRRootParameterType, IRRootSignature,
-    IRRootSignatureDescriptor1, IRRootSignatureFlags, IRRootSignatureVersion, IRShaderStage,
-    IRShaderVisibility, IRStaticBorderColor, IRStaticSamplerDescriptor, IRTextureAddressMode,
-    IRVersionedRootSignatureDescriptor, IRVersionedRootSignatureDescriptor_u,
+    IRComparisonFunction, IRCompiler, IRFilter, IRMetalLibBinary, IRObject, IRReflectionVersion,
+    IRRootConstants, IRRootDescriptor1, IRRootParameter1, IRRootParameter1_u, IRRootParameterType,
+    IRRootSignature, IRRootSignatureDescriptor1, IRRootSignatureFlags, IRRootSignatureVersion,
+    IRShaderReflection, IRShaderStage, IRShaderVisibility, IRStaticBorderColor,
+    IRStaticSamplerDescriptor, IRTextureAddressMode, IRVersionedRootSignatureDescriptor,
+    IRVersionedRootSignatureDescriptor_u,
 };
 
 fn create_static_sampler(
@@ -125,9 +126,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let root_sig = IRRootSignature::create_from_descriptor(&lib, &desc)?;
 
-        let egui_update = include_bytes!(
-            "C:/Users/Jasper/traverse/breda/crates/breda-egui/assets/shaders/egui_update.cs.dxil"
-        );
+        let egui_update =
+            include_bytes!("D:/breda/crates/breda-egui/assets/shaders/egui_update.cs.dxil");
         // let memcpy = include_bytes!("C:/Users/Jasper/traverse/breda/apps/cs-memcpy/assets/shaders/memcpy.cs.dxil");
 
         let mut mtl_binary = IRMetalLibBinary::new(&lib)?;
@@ -139,6 +139,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         dbg!(mtllib.get_type());
         dbg!(mtllib.get_metal_ir_shader_stage());
         mtllib.get_metal_lib_binary(IRShaderStage::IRShaderStageCompute, &mut mtl_binary);
+
+        let mut mtl_reflection = IRShaderReflection::new(&lib)?;
+        dbg!(mtllib.get_reflection(IRShaderStage::IRShaderStageCompute, &mut mtl_reflection));
+        dbg!(
+            mtl_reflection
+                .get_compute_info(IRReflectionVersion::IRReflectionVersion_1_0)
+                .unwrap()
+                .u
+                .info_1_0
+        );
+
         dbg!(mtl_binary.get_byte_code().len());
         std::fs::write("out.bin", mtl_binary.get_byte_code());
     }


### PR DESCRIPTION
We need this info to be able to properly dispatch a compute shader of the correct size.