### PR TITLE
CI: Build-test documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Cargo test
         run: cargo test --workspace
+      - name: Cargo doc
+        run: cargo doc --workspace --all-features --no-deps --document-private-items
 
   generate-rust:
     name: Generate Rust crate


### PR DESCRIPTION
This makes sure we have no stale intradoc links or broken formatting, before eventually releasing the crate and having info up at docs.rs.
