### PR TITLE
🦹‍♂️ Add missing functions to set minimum OS and GPU targets on `IRCompiler`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,33 @@ impl IRCompiler {
         }
     }
 
+    #[doc(alias = "IRCompilerSetMinimumDeploymentTarget")]
+    pub fn set_minimum_deployment_target(
+        &mut self,
+        operating_system: ffi::IROperatingSystem,
+        version: &CStr,
+    ) {
+        unsafe {
+            self.funcs.IRCompilerSetMinimumDeploymentTarget(
+                self.me.as_ptr(),
+                operating_system,
+                version.as_ptr(),
+            )
+        }
+    }
+
+    /// See <https://developer.apple.com/documentation/metal/mtlgpufamily> for a list of GPU
+    /// families and the hardware that they correspond to.
+    /// See <https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf> for a specific
+    /// table denoting supported features per GPU family.
+    #[doc(alias = "IRCompilerSetMinimumGPUFamily")]
+    pub fn set_minimum_gpu_family(&mut self, family: ffi::IRGPUFamily) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetMinimumGPUFamily(self.me.as_ptr(), family)
+        }
+    }
+
     #[doc(alias = "IRCompilerAllocCompileAndLink")]
     pub fn alloc_compile_and_link(
         &self,


### PR DESCRIPTION
By setting the minimum targets that emitted Metal shaders should support, we may not only be opting out of potential optimizations that are only supported on newer OS versions or GPUs (i.e. per the feature tables at) https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf) but also receive adequate errors when features used in shaders are not supported by the given minimum target, such as:

    IRError { code: UnsupportedInstruction, payload: "IR contains unsupported instruction: \"dx.op.atomicBinOp.i32\". Target minimum OS build version does not support texture atomics" }

(This happens when setting the deployment target to MacOS 13, as texture atomics are only supported on MacOS 14 onwards)

Unfortunately the compiler also throws a related error on one of our shaders regardless of the deployment target we set, as if there's a (broken) requirement to not set `minimumDeploymentTarget` higher than the machine that `metal_irconverter` is running on?

    IRError { code: UnableToLinkModule, payload: "Error linking metallib. Please verify that the minimumDeploymentTarget is equal or lower than your operating system version." }
