### PR TITLE
Make `IRIntrinsicMask*All` match the `u64` type of `IRCompilerSetRayTracingPipelineArguments()`

### DIFF
--- a/bindings_generator/src/main.rs
+++ b/bindings_generator/src/main.rs
@@ -117,4 +117,13 @@ impl ParseCallbacks for RenameCallback {
         }
         None
     }
+
+    fn int_macro(&self, name: &str, _value: i64) -> Option<bindgen::callbacks::IntKind> {
+        if name.starts_with("IRIntrinsicMask") {
+            // Match the argument type passed to IRCompilerSetRayTracingPipelineArguments
+            Some(bindgen::callbacks::IntKind::U64)
+        } else {
+            None
+        }
+    }
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -4,9 +4,9 @@ pub const IR_VERSION_MAJOR: u32 = 2;
 pub const IR_VERSION_MINOR: u32 = 0;
 pub const IR_VERSION_PATCH: u32 = 4;
 pub const IRDescriptorRangeOffsetAppend: u32 = 4294967295;
-pub const IRIntrinsicMaskClosestHitAll: u32 = 2147483647;
-pub const IRIntrinsicMaskMissShaderAll: u32 = 32767;
-pub const IRIntrinsicMaskCallableShaderAll: u32 = 28735;
+pub const IRIntrinsicMaskClosestHitAll: u64 = 2147483647;
+pub const IRIntrinsicMaskMissShaderAll: u64 = 32767;
+pub const IRIntrinsicMaskCallableShaderAll: u64 = 28735;
 pub const IRRayTracingUnlimitedRecursionDepth: i32 = -1;
 #[repr(u32)]
 #[non_exhaustive]


### PR DESCRIPTION
So that callers can pass this type to the function without having to cast.
