### PR TITLE
Release 0.2.0-beta.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,9 @@ name: Publish
 on:
   push:
     tags:
-    paths: "/Cargo.toml"
+    paths:
+      - "/Cargo.toml"
+      - "/runtime/Cargo.toml"
 
 jobs:
   Publish:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saxaboom"
-version = "0.1.0+irconverter-2.0"
+version = "0.2.0-beta.1+irconverter-2.0.4"
 authors = ["Traverse Research <support@traverseresearch.nl>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-saxaboom = "0.1.0"
+saxaboom = "0.2.0-beta.1"
 ```
 
 Example to compile `DXIL` to `metallib`:

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saxaboom-runtime"
-version = "0.1.0+irconverter-2.0"
+version = "0.2.0-beta.1+irconverter-2.0.4"
 authors = ["Traverse Research <support@traverseresearch.nl>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-saxaboom-runtime = "0.1.0"
+saxaboom-runtime = "0.2.0-beta.1"
 ```
 
 Example to create a descriptor to a buffer:


### PR DESCRIPTION
Beta release because this uses IRConverter 2.0 beta 4 which isn't stable itself yet.
