### PR TITLE
🏊‍♀️ Switch `saxaboom` to `objc2`

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,4 +21,4 @@ targets = [
 
 [dependencies]
 objc2 = { version = "0.5", default-features = false }
-objc2-metal = { version = "0.2.2", default-features = false, features = ["alloc", "std", "MTLResource", "MTLBuffer", "MTLTexture", "MTLSampler", "MTLTypes"] }
+objc2-metal = { version = "0.2.2", default-features = false, features = ["std", "MTLResource", "MTLBuffer", "MTLTexture", "MTLSampler", "MTLTypes"] }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,4 +20,5 @@ targets = [
 ]
 
 [dependencies]
-metal = { version = "0.29", default-features = false }
+objc2 = { version = "0.5", default-features = false }
+objc2-metal = { version = "0.2.2", default-features = false, features = ["alloc", "std", "MTLResource", "MTLBuffer", "MTLTexture", "MTLSampler", "MTLTypes"] }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -15,7 +15,7 @@ pub mod bindings {
 pub use bindings as ffi;
 
 use objc2::runtime::ProtocolObject;
-use objc2_metal::{MTLBuffer, MTLSamplerState, MTLTexture};
+use objc2_metal::{MTLBuffer, MTLResourceID, MTLSamplerState, MTLTexture};
 
 /// Rust version of `IRBufferView` using [`metal`] types.
 #[doc(alias = "IRBufferView")]
@@ -58,7 +58,7 @@ impl ffi::IRDescriptorTableEntry {
             gpuVA: buffer_view.buffer.gpuAddress() + buffer_view.buffer_offset,
             textureViewID: match buffer_view.texture_buffer_view {
                 Some(texture) => unsafe {
-                    std::mem::transmute::<objc2_metal::MTLResourceID, u64>(texture.gpuResourceID())
+                    std::mem::transmute::<MTLResourceID, u64>(texture.gpuResourceID())
                 },
                 None => 0,
             },
@@ -76,7 +76,7 @@ impl ffi::IRDescriptorTableEntry {
         Self {
             gpuVA: 0,
             textureViewID: unsafe {
-                std::mem::transmute::<objc2_metal::MTLResourceID, u64>(argument.gpuResourceID())
+                std::mem::transmute::<MTLResourceID, u64>(argument.gpuResourceID())
             },
             metadata: min_lod_clamp.to_bits() as u64 | (METADATA as u64) << 32,
         }
@@ -90,9 +90,7 @@ impl ffi::IRDescriptorTableEntry {
     #[allow(unused_variables, unreachable_code, dead_code)]
     pub fn sampler(argument: &ProtocolObject<dyn MTLSamplerState>, lod_bias: f32) -> Self {
         Self {
-            gpuVA: unsafe {
-                std::mem::transmute::<objc2_metal::MTLResourceID, u64>(argument.gpuResourceID())
-            },
+            gpuVA: unsafe { std::mem::transmute::<MTLResourceID, u64>(argument.gpuResourceID()) },
             textureViewID: 0,
             metadata: lod_bias.to_bits() as u64,
         }


### PR DESCRIPTION
Does what it says on the tin, same as on `gpu-allocator`

It would be nice to have https://github.com/madsmtm/objc2/issues/660 address tho, but it's not strictly required for now since it requires spinning a new release and I don't think we have to wait that long for this to get merged.