### PR TITLE
Upgrade to `objc2 0.6` and `objc2-metal 0.3`

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,5 +21,5 @@ targets = [
 ]
 
 [dependencies]
-objc2 = { version = "0.5", default-features = false }
-objc2-metal = { version = "0.2.2", default-features = false, features = ["std", "MTLResource", "MTLBuffer", "MTLTexture", "MTLSampler", "MTLTypes"] }
+objc2 = { version = "0.6", default-features = false }
+objc2-metal = { version = "0.3", default-features = false, features = ["std", "MTLAllocation", "MTLResource", "MTLBuffer", "MTLTexture", "MTLSampler", "MTLTypes"] }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -17,7 +17,7 @@ pub mod bindings {
 pub use bindings as ffi;
 
 use objc2::runtime::ProtocolObject;
-use objc2_metal::{MTLBuffer, MTLResourceID, MTLSamplerState, MTLTexture};
+use objc2_metal::{MTLBuffer, MTLSamplerState, MTLTexture};
 
 /// Rust version of `IRBufferView` using [`metal`] types.
 #[doc(alias = "IRBufferView")]
@@ -59,9 +59,7 @@ impl ffi::IRDescriptorTableEntry {
         Self {
             gpuVA: buffer_view.buffer.gpuAddress() + buffer_view.buffer_offset,
             textureViewID: match buffer_view.texture_buffer_view {
-                Some(texture) => unsafe {
-                    std::mem::transmute::<MTLResourceID, u64>(texture.gpuResourceID())
-                },
+                Some(texture) => unsafe { texture.gpuResourceID() }.to_raw(),
                 None => 0,
             },
             metadata: Self::buffer_metadata(buffer_view),
@@ -77,9 +75,7 @@ impl ffi::IRDescriptorTableEntry {
         const METADATA: u32 = 0; // According to the current docs, the metadata must be 0
         Self {
             gpuVA: 0,
-            textureViewID: unsafe {
-                std::mem::transmute::<MTLResourceID, u64>(argument.gpuResourceID())
-            },
+            textureViewID: unsafe { argument.gpuResourceID() }.to_raw(),
             metadata: min_lod_clamp.to_bits() as u64 | (METADATA as u64) << 32,
         }
     }
@@ -91,7 +87,7 @@ impl ffi::IRDescriptorTableEntry {
     #[doc(alias = "IRDescriptorTableSetSampler")]
     pub fn sampler(argument: &ProtocolObject<dyn MTLSamplerState>, lod_bias: f32) -> Self {
         Self {
-            gpuVA: unsafe { std::mem::transmute::<MTLResourceID, u64>(argument.gpuResourceID()) },
+            gpuVA: unsafe { argument.gpuResourceID() }.to_raw(),
             textureViewID: 0,
             metadata: lod_bias.to_bits() as u64,
         }


### PR DESCRIPTION
`objc2-metal` has a new `to_raw()` function for converting `MTLResourceID` to its raw representation, as used in a few structures as a raw integer.

Note also that a new `MTLAllocation` interface was added to Metal.  Even if that interface is _optional_, current `objc2` design requires this trait to be part of the hierarchy (and the feature explicitly enabled) to get access to all "descendant" interfaces (`MTLResource`, which provides `MTLBuffer` and `MTLTexture`). There are upstream plans to see if this can be simplified: https://github.com/madsmtm/objc2/issues/663.