### PR TITLE
Revert "Update thiserror requirement from 1.0 to 2.0"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ members = [
 
 [dependencies]
 libloading = "0.8"
-thiserror = "2.0"
+thiserror = "1.0"


### PR DESCRIPTION
Reverts Traverse-Research/saxaboom#29

Lets delay this a bit longer since it has some downstream effects for our crates.