### PR TITLE
Release 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saxaboom"
-version = "0.2.0-beta.1+irconverter-2.0"
+version = "0.2.0+irconverter-2.0"
 authors = ["Traverse Research <support@traverseresearch.nl>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-saxaboom = "0.2.0-beta.1"
+saxaboom = "0.2.0"
 ```
 
 Example to compile `DXIL` to `metallib`:

--- a/release.toml
+++ b/release.toml
@@ -15,5 +15,5 @@ pre-release-replacements = [
 # though), or by using the same version for all packages.
 # https://github.com/crate-ci/cargo-release/issues/540#issuecomment-1328769105
 # https://github.com/crate-ci/cargo-release/commit/3af94caa4b9bbee010a5cf3f196cc4afffbaf192
-consolidate-commits = false
+consolidate-commits = true
 shared-version = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saxaboom-runtime"
-version = "0.2.0-beta.1+irconverter-2.0"
+version = "0.2.0+irconverter-2.0"
 authors = ["Traverse Research <support@traverseresearch.nl>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-saxaboom-runtime = "0.2.0-beta.1"
+saxaboom-runtime = "0.2.0"
 ```
 
 Example to create a descriptor to a buffer:


### PR DESCRIPTION
Now that we upgraded to the non-beta `metal_irconverter 2.0.5` release (the latest before `2.1`, but that one contains no code/binding changes), drop our `-beta.1` suffix and release a full new version of `saxaboom(-runtime)`!

Generated with:

```console
$ cargo release 0.2.0 -p saxaboom -p saxaboom-runtime -x
```
