### PR TITLE
Add missing `set_*` and other bindings to `IRConverter`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,11 +321,62 @@ impl Drop for IRCompiler {
 }
 
 impl IRCompiler {
+    #[doc(alias = "IRCompilerSetValidationFlags")]
+    pub fn set_validation_flags(&mut self, validation_flags: ffi::IRCompilerValidationFlags) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetValidationFlags(self.me.as_ptr(), validation_flags)
+        }
+    }
+
+    #[doc(alias = "IRCompilerSetStageInGenerationMode")]
+    pub fn set_stage_in_generation_mode(&mut self, stage: ffi::IRStageInCodeGenerationMode) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetStageInGenerationMode(self.me.as_ptr(), stage)
+        }
+    }
+
+    // TODO: Requires layout
+    // #[must_use]
+    // #[doc(alias = "IRMetalLibSynthesizeStageInFunction")]
+    // pub fn synthesize_stage_in_function(
+    //     &mut self,
+    //     vertex_shader_reflection: &IRShaderReflection,
+    //     layout: impl Into<IRVersionedInputLayoutDescriptor>,
+    //     binary: &IRMetalLibBinary,
+    // ) -> bool {
+    //     unsafe {
+    //         self.funcs.IRMetalLibSynthesizeStageInFunction(
+    //             self.me.as_ptr(),
+    //             vertex_shader_reflection.me.as_ptr(),
+    //             &layout.into(),
+    //             binary.me.as_ptr(),
+    //         )
+    //     }
+    // }
+
     #[doc(alias = "IRCompilerSetGlobalRootSignature")]
     pub fn set_global_root_signature(&mut self, root_signature: &IRRootSignature) {
         unsafe {
             self.funcs
                 .IRCompilerSetGlobalRootSignature(self.me.as_ptr(), root_signature.me.as_ptr())
+        }
+    }
+
+    #[doc(alias = "IRCompilerSetLocalRootSignature")]
+    pub fn set_local_root_signature(&mut self, root_signature: &IRRootSignature) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetLocalRootSignature(self.me.as_ptr(), root_signature.me.as_ptr())
+        }
+    }
+
+    #[doc(alias = "IRCompilerSetHitgroupType")]
+    pub fn set_hitgroup_type(&mut self, hit_group_type: ffi::IRHitGroupType) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetHitgroupType(self.me.as_ptr(), hit_group_type)
         }
     }
 
@@ -359,26 +410,57 @@ impl IRCompiler {
         }
     }
 
-    #[doc(alias = "IRCompilerSetHitgroupType")]
-    pub fn set_hitgroup_type(&mut self, hit_group_type: ffi::IRHitGroupType) {
+    #[doc(alias = "IRCompilerSetCompatibilityFlags")]
+    pub fn set_compatibility_flags(&mut self, flags: ffi::IRCompatibilityFlags) {
         unsafe {
             self.funcs
-                .IRCompilerSetHitgroupType(self.me.as_ptr(), hit_group_type)
+                .IRCompilerSetCompatibilityFlags(self.me.as_ptr(), flags)
         }
     }
 
-    #[doc(alias = "IRMetalLibSynthesizeIndirectIntersectionFunction")]
-    pub fn synthesize_indirect_intersection_function(&mut self) -> Option<IRMetalLibBinary> {
-        let binary = IRMetalLibBinary::new(self.funcs.clone());
-        if unsafe {
-            self.funcs.IRMetalLibSynthesizeIndirectIntersectionFunction(
-                self.me.as_ptr(),
-                binary.me.as_ptr(),
-            )
-        } {
-            Some(binary)
-        } else {
-            None
+    #[doc(alias = "IRCompilerSetInputTopology")]
+    pub fn set_input_topology(&mut self, input_topology: ffi::IRInputTopology) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetInputTopology(self.me.as_ptr(), input_topology)
+        }
+    }
+
+    #[doc(alias = "IRCompilerEnableGeometryAndTessellationEmulation")]
+    pub fn enable_geometry_and_tessellation_emulation(&mut self, enable: bool) {
+        unsafe {
+            self.funcs
+                .IRCompilerEnableGeometryAndTessellationEmulation(self.me.as_ptr(), enable)
+        }
+    }
+
+    #[doc(alias = "IRCompilerSetDualSourceBlendingConfiguration")]
+    pub fn set_dual_source_blending_configuration(
+        &mut self,
+        configuration: ffi::IRDualSourceBlendingConfiguration,
+    ) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetDualSourceBlendingConfiguration(self.me.as_ptr(), configuration)
+        }
+    }
+
+    #[doc(alias = "IRCompilerSetDepthFeedbackConfiguration")]
+    pub fn set_depth_feedback_configuration(
+        &mut self,
+        configuration: ffi::IRDepthFeedbackConfiguration,
+    ) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetDepthFeedbackConfiguration(self.me.as_ptr(), configuration)
+        }
+    }
+
+    #[doc(alias = "IRCompilerSetIntRTMask")]
+    pub fn set_int_rt_mask(&mut self, int_rt_mask: u8) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetIntRTMask(self.me.as_ptr(), int_rt_mask)
         }
     }
 
@@ -397,11 +479,54 @@ impl IRCompiler {
         }
     }
 
+    #[doc(alias = "IRMetalLibSynthesizeIndirectIntersectionFunction")]
+    pub fn synthesize_indirect_intersection_function(&mut self) -> Option<IRMetalLibBinary> {
+        let binary = IRMetalLibBinary::new(self.funcs.clone());
+        if unsafe {
+            self.funcs.IRMetalLibSynthesizeIndirectIntersectionFunction(
+                self.me.as_ptr(),
+                binary.me.as_ptr(),
+            )
+        } {
+            Some(binary)
+        } else {
+            None
+        }
+    }
+
     #[doc(alias = "IRCompilerSetEntryPointName")]
     pub fn set_entry_point_name(&mut self, new_name: &CStr) {
         unsafe {
             self.funcs
                 .IRCompilerSetEntryPointName(self.me.as_ptr(), new_name.as_ptr())
+        }
+    }
+
+    /// See <https://developer.apple.com/documentation/metal/mtlgpufamily> for a list of GPU
+    /// families and the hardware that they correspond to.
+    /// See <https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf> for a specific
+    /// table denoting supported features per GPU family.
+    #[doc(alias = "IRCompilerSetMinimumGPUFamily")]
+    pub fn set_minimum_gpu_family(&mut self, family: ffi::IRGPUFamily) {
+        unsafe {
+            self.funcs
+                .IRCompilerSetMinimumGPUFamily(self.me.as_ptr(), family)
+        }
+    }
+
+    #[doc(alias = "IRCompilerIgnoreRootSignature")]
+    pub fn ignore_root_signature(&mut self, ignore_embedded_root_signature: bool) {
+        unsafe {
+            self.funcs
+                .IRCompilerIgnoreRootSignature(self.me.as_ptr(), ignore_embedded_root_signature)
+        }
+    }
+
+    #[doc(alias = "IRCompilerIgnoreDebugInformation")]
+    pub fn ignore_debug_information(&mut self, ignore_debug_information: bool) {
+        unsafe {
+            self.funcs
+                .IRCompilerIgnoreDebugInformation(self.me.as_ptr(), ignore_debug_information)
         }
     }
 
@@ -417,18 +542,6 @@ impl IRCompiler {
                 operating_system,
                 version.as_ptr(),
             )
-        }
-    }
-
-    /// See <https://developer.apple.com/documentation/metal/mtlgpufamily> for a list of GPU
-    /// families and the hardware that they correspond to.
-    /// See <https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf> for a specific
-    /// table denoting supported features per GPU family.
-    #[doc(alias = "IRCompilerSetMinimumGPUFamily")]
-    pub fn set_minimum_gpu_family(&mut self, family: ffi::IRGPUFamily) {
-        unsafe {
-            self.funcs
-                .IRCompilerSetMinimumGPUFamily(self.me.as_ptr(), family)
         }
     }
 
@@ -458,7 +571,41 @@ impl IRCompiler {
             object.expect("IRCompilerAllocCompileAndLink should not return NULL without error");
         Ok(IRObject {
             me: object,
-            funcs: input.funcs.clone(),
+            funcs: self.funcs.clone(),
+        })
+    }
+
+    #[doc(alias = "IRCompilerAllocCombineCompileAndLink")]
+    pub fn alloc_combine_compile_and_link(
+        &self,
+        intersection_function_entry_point: &CStr,
+        intersection_function_bytecode: &IRObject,
+        any_hit_function_entry_point: &CStr,
+        any_hit_function_bytecode: &IRObject,
+    ) -> Result<IRObject, CompilerError> {
+        let mut error = std::ptr::null_mut();
+
+        let object = NonNull::new(unsafe {
+            self.funcs.IRCompilerAllocCombineCompileAndLink(
+                self.me.as_ptr(),
+                intersection_function_entry_point.as_ptr(),
+                intersection_function_bytecode.me.as_ptr(),
+                any_hit_function_entry_point.as_ptr(),
+                any_hit_function_bytecode.me.as_ptr(),
+                &mut error,
+            )
+        });
+
+        if let Some(error) = NonNull::new(error) {
+            let error = unsafe { IRError::from_ptr(error, self.funcs.clone()) };
+            return Err(CompilerError(error));
+        }
+
+        let object = object
+            .expect("IRCompilerAllocCombineCompileAndLink should not return NULL without error");
+        Ok(IRObject {
+            me: object,
+            funcs: self.funcs.clone(),
         })
     }
 }


### PR DESCRIPTION
There are a bunch of functions missing on `IRCompiler`, specifically a bunch of setters for booleans and flags, which I think we should have and are trivial to add.
