### PR TITLE
runtime: Implement some "inline" header functions in Rust

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,4 +22,15 @@ targets = [
 
 [dependencies]
 objc2 = { version = "0.6", default-features = false }
-objc2-metal = { version = "0.3", default-features = false, features = ["std", "MTLAllocation", "MTLResource", "MTLBuffer", "MTLTexture", "MTLSampler", "MTLTypes"] }
+objc2-metal = { version = "0.3", default-features = false, features = [
+  "std",
+  "MTLAllocation",
+  "MTLBuffer",
+  "MTLCommandEncoder",
+  "MTLRenderCommandEncoder",
+  "MTLResource",
+  "MTLSampler",
+  "MTLStageInputOutputDescriptor",
+  "MTLTexture",
+  "MTLTypes",
+] }


### PR DESCRIPTION
`metal_irconverter_runtime.h` defines a couple critical helper functions to utilize generated/synthesized Metal shaders, by setting up specific compatible state in the render encoder (for example) that has to match the generated shaders.  Since compiling this header in-place within this Rust project (and linking the result statically) would be tedious, implement the functions by hand based on `objc2-metal` primitives.

Having this in `saxaboom-runtime` is the right place since it already provides other runtime bindings based on `objc2-metal` (that were also originally extracted from the inline header implementation!), and makes it easier to update when a header update (checked in to this repo, so that we can see a diff!) indicates their implementations are being changed.

Note that this is by no means a complete list of these functions and any missing binding can trivially be added and published as a patch release in the future.
