### PR TITLE
Add reflection info for all shader stages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,10 +131,16 @@ macro_rules! verioned_info {
                         .funcs
                         .$create(reflection.me.as_ptr(), version, info.as_mut_ptr());
 
-                success.then(|| Self {
+                if !success {
+                    return None;
+                }
+
+                let info = Self {
                     me: info.assume_init(),
                     funcs: Arc::clone(&reflection.funcs),
-                })
+                };
+
+                Some(info)
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,22 +126,18 @@ macro_rules! versioned_info {
                 version: ffi::IRReflectionVersion,
             ) -> Option<Self> {
                 let mut info = MaybeUninit::uninit();
-                let success = unsafe {
+                if unsafe {
                     reflection
                         .funcs
                         .$create(reflection.me.as_ptr(), version, info.as_mut_ptr())
-                };
-
-                if !success {
-                    return None;
+                } {
+                    Some(Self {
+                        me: unsafe { info.assume_init() },
+                        funcs: Arc::clone(&reflection.funcs),
+                    })
+                } else {
+                    None
                 }
-
-                let info = Self {
-                    me: unsafe { info.assume_init() },
-                    funcs: Arc::clone(&reflection.funcs),
-                };
-
-                Some(info)
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,35 +99,7 @@ impl MetalIrConverter {
     }
 }
 
-pub struct IRShaderReflection {
-    me: NonNull<bindings::IRShaderReflection>,
-    funcs: Arc<bindings::metal_irconverter>,
-}
-
-impl Drop for IRShaderReflection {
-    #[doc(alias = "IRShaderReflectionDestroy")]
-    fn drop(&mut self) {
-        unsafe { self.funcs.IRShaderReflectionDestroy(self.me.as_ptr()) }
-    }
-}
-
-impl IRShaderReflection {
-    /// **Private** function that's not on [`MetalIrConverter`] because it is only used internally
-    /// to return initialized objects.
-    #[doc(alias = "IRShaderReflectionCreate")]
-    fn new(funcs: Arc<bindings::metal_irconverter>) -> Self {
-        let me = NonNull::new(unsafe { funcs.IRShaderReflectionCreate() })
-            .expect("Failed to create IRShaderReflection");
-        Self { me, funcs }
-    }
-
-    #[doc(alias = "IRShaderReflectionCopyComputeInfo")]
-    pub fn compute_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedCSInfo> {
-        unsafe { IRVersionedCSInfo::new(self, version) }
-    }
-}
-
-macro_rules! impl_verioned_info {
+macro_rules! verioned_info {
     ($name:ident, $create:ident, $release:ident) => {
         pub struct $name {
             me: ffi::$name,
@@ -168,11 +140,130 @@ macro_rules! impl_verioned_info {
     };
 }
 
-impl_verioned_info!(
+verioned_info!(
     IRVersionedCSInfo,
     IRShaderReflectionCopyComputeInfo,
     IRShaderReflectionReleaseComputeInfo
 );
+
+verioned_info!(
+    IRVersionedVSInfo,
+    IRShaderReflectionCopyVertexInfo,
+    IRShaderReflectionReleaseVertexInfo
+);
+
+verioned_info!(
+    IRVersionedFSInfo,
+    IRShaderReflectionCopyFragmentInfo,
+    IRShaderReflectionReleaseFragmentInfo
+);
+
+verioned_info!(
+    IRVersionedGSInfo,
+    IRShaderReflectionCopyGeometryInfo,
+    IRShaderReflectionReleaseGeometryInfo
+);
+
+verioned_info!(
+    IRVersionedHSInfo,
+    IRShaderReflectionCopyHullInfo,
+    IRShaderReflectionReleaseHullInfo
+);
+
+verioned_info!(
+    IRVersionedDSInfo,
+    IRShaderReflectionCopyDomainInfo,
+    IRShaderReflectionReleaseDomainInfo
+);
+
+verioned_info!(
+    IRVersionedMSInfo,
+    IRShaderReflectionCopyMeshInfo,
+    IRShaderReflectionReleaseMeshInfo
+);
+
+verioned_info!(
+    IRVersionedASInfo,
+    IRShaderReflectionCopyAmplificationInfo,
+    IRShaderReflectionReleaseAmplificationInfo
+);
+
+verioned_info!(
+    IRVersionedRTInfo,
+    IRShaderReflectionCopyRaytracingInfo,
+    IRShaderReflectionReleaseRaytracingInfo
+);
+
+pub struct IRShaderReflection {
+    me: NonNull<bindings::IRShaderReflection>,
+    funcs: Arc<bindings::metal_irconverter>,
+}
+
+impl Drop for IRShaderReflection {
+    #[doc(alias = "IRShaderReflectionDestroy")]
+    fn drop(&mut self) {
+        unsafe { self.funcs.IRShaderReflectionDestroy(self.me.as_ptr()) }
+    }
+}
+
+impl IRShaderReflection {
+    /// **Private** function that's not on [`MetalIrConverter`] because it is only used internally
+    /// to return initialized objects.
+    #[doc(alias = "IRShaderReflectionCreate")]
+    fn new(funcs: Arc<bindings::metal_irconverter>) -> Self {
+        let me = NonNull::new(unsafe { funcs.IRShaderReflectionCreate() })
+            .expect("Failed to create IRShaderReflection");
+        Self { me, funcs }
+    }
+
+    #[doc(alias = "IRShaderReflectionCopyVertexInfo")]
+    pub fn vertex_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedVSInfo> {
+        unsafe { IRVersionedVSInfo::new(self, version) }
+    }
+
+    #[doc(alias = "IRShaderReflectionCopyFragmentInfo")]
+    pub fn fragment_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedFSInfo> {
+        unsafe { IRVersionedFSInfo::new(self, version) }
+    }
+
+    #[doc(alias = "IRShaderReflectionCopyGeometryInfo")]
+    pub fn geometry_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedGSInfo> {
+        unsafe { IRVersionedGSInfo::new(self, version) }
+    }
+
+    #[doc(alias = "IRShaderReflectionCopyHullInfo")]
+    pub fn hull_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedHSInfo> {
+        unsafe { IRVersionedHSInfo::new(self, version) }
+    }
+
+    #[doc(alias = "IRShaderReflectionCopyDomainInfo")]
+    pub fn domain_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedDSInfo> {
+        unsafe { IRVersionedDSInfo::new(self, version) }
+    }
+
+    #[doc(alias = "IRShaderReflectionCopyMeshInfo")]
+    pub fn mesh_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedMSInfo> {
+        unsafe { IRVersionedMSInfo::new(self, version) }
+    }
+
+    #[doc(alias = "IRShaderReflectionCopyAmplificationInfo")]
+    pub fn amplification_info(
+        &self,
+        version: ffi::IRReflectionVersion,
+    ) -> Option<IRVersionedASInfo> {
+        unsafe { IRVersionedASInfo::new(self, version) }
+    }
+
+    #[doc(alias = "IRShaderReflectionCopyComputeInfo")]
+    pub fn compute_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedCSInfo> {
+        unsafe { IRVersionedCSInfo::new(self, version) }
+    }
+
+    #[doc(alias = "IRShaderReflectionCopyRaytracingInfo")]
+    pub fn raytracing_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedRTInfo> {
+        unsafe { IRVersionedRTInfo::new(self, version) }
+    }
+}
 
 pub struct IRObject {
     me: NonNull<bindings::IRObject>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,22 +121,23 @@ macro_rules! versioned_info {
         }
 
         impl $name {
-            unsafe fn new(
+            fn new(
                 reflection: &IRShaderReflection,
                 version: ffi::IRReflectionVersion,
             ) -> Option<Self> {
                 let mut info = MaybeUninit::uninit();
-                let success =
+                let success = unsafe {
                     reflection
                         .funcs
-                        .$create(reflection.me.as_ptr(), version, info.as_mut_ptr());
+                        .$create(reflection.me.as_ptr(), version, info.as_mut_ptr())
+                };
 
                 if !success {
                     return None;
                 }
 
                 let info = Self {
-                    me: info.assume_init(),
+                    me: unsafe { info.assume_init() },
                     funcs: Arc::clone(&reflection.funcs),
                 };
 
@@ -224,32 +225,32 @@ impl IRShaderReflection {
 
     #[doc(alias = "IRShaderReflectionCopyVertexInfo")]
     pub fn vertex_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedVSInfo> {
-        unsafe { IRVersionedVSInfo::new(self, version) }
+        IRVersionedVSInfo::new(self, version)
     }
 
     #[doc(alias = "IRShaderReflectionCopyFragmentInfo")]
     pub fn fragment_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedFSInfo> {
-        unsafe { IRVersionedFSInfo::new(self, version) }
+        IRVersionedFSInfo::new(self, version)
     }
 
     #[doc(alias = "IRShaderReflectionCopyGeometryInfo")]
     pub fn geometry_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedGSInfo> {
-        unsafe { IRVersionedGSInfo::new(self, version) }
+        IRVersionedGSInfo::new(self, version)
     }
 
     #[doc(alias = "IRShaderReflectionCopyHullInfo")]
     pub fn hull_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedHSInfo> {
-        unsafe { IRVersionedHSInfo::new(self, version) }
+        IRVersionedHSInfo::new(self, version)
     }
 
     #[doc(alias = "IRShaderReflectionCopyDomainInfo")]
     pub fn domain_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedDSInfo> {
-        unsafe { IRVersionedDSInfo::new(self, version) }
+        IRVersionedDSInfo::new(self, version)
     }
 
     #[doc(alias = "IRShaderReflectionCopyMeshInfo")]
     pub fn mesh_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedMSInfo> {
-        unsafe { IRVersionedMSInfo::new(self, version) }
+        IRVersionedMSInfo::new(self, version)
     }
 
     #[doc(alias = "IRShaderReflectionCopyAmplificationInfo")]
@@ -257,17 +258,17 @@ impl IRShaderReflection {
         &self,
         version: ffi::IRReflectionVersion,
     ) -> Option<IRVersionedASInfo> {
-        unsafe { IRVersionedASInfo::new(self, version) }
+        IRVersionedASInfo::new(self, version)
     }
 
     #[doc(alias = "IRShaderReflectionCopyComputeInfo")]
     pub fn compute_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedCSInfo> {
-        unsafe { IRVersionedCSInfo::new(self, version) }
+        IRVersionedCSInfo::new(self, version)
     }
 
     #[doc(alias = "IRShaderReflectionCopyRaytracingInfo")]
     pub fn raytracing_info(&self, version: ffi::IRReflectionVersion) -> Option<IRVersionedRTInfo> {
-        unsafe { IRVersionedRTInfo::new(self, version) }
+        IRVersionedRTInfo::new(self, version)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ impl MetalIrConverter {
     }
 }
 
-macro_rules! verioned_info {
+macro_rules! versioned_info {
     ($name:ident, $create:ident, $release:ident) => {
         pub struct $name {
             me: ffi::$name,
@@ -146,55 +146,55 @@ macro_rules! verioned_info {
     };
 }
 
-verioned_info!(
+versioned_info!(
     IRVersionedCSInfo,
     IRShaderReflectionCopyComputeInfo,
     IRShaderReflectionReleaseComputeInfo
 );
 
-verioned_info!(
+versioned_info!(
     IRVersionedVSInfo,
     IRShaderReflectionCopyVertexInfo,
     IRShaderReflectionReleaseVertexInfo
 );
 
-verioned_info!(
+versioned_info!(
     IRVersionedFSInfo,
     IRShaderReflectionCopyFragmentInfo,
     IRShaderReflectionReleaseFragmentInfo
 );
 
-verioned_info!(
+versioned_info!(
     IRVersionedGSInfo,
     IRShaderReflectionCopyGeometryInfo,
     IRShaderReflectionReleaseGeometryInfo
 );
 
-verioned_info!(
+versioned_info!(
     IRVersionedHSInfo,
     IRShaderReflectionCopyHullInfo,
     IRShaderReflectionReleaseHullInfo
 );
 
-verioned_info!(
+versioned_info!(
     IRVersionedDSInfo,
     IRShaderReflectionCopyDomainInfo,
     IRShaderReflectionReleaseDomainInfo
 );
 
-verioned_info!(
+versioned_info!(
     IRVersionedMSInfo,
     IRShaderReflectionCopyMeshInfo,
     IRShaderReflectionReleaseMeshInfo
 );
 
-verioned_info!(
+versioned_info!(
     IRVersionedASInfo,
     IRShaderReflectionCopyAmplificationInfo,
     IRShaderReflectionReleaseAmplificationInfo
 );
 
-verioned_info!(
+versioned_info!(
     IRVersionedRTInfo,
     IRShaderReflectionCopyRaytracingInfo,
     IRShaderReflectionReleaseRaytracingInfo


### PR DESCRIPTION
Similar to [`compute_info`](https://github.com/Traverse-Research/saxaboom/blob/ee58c32ec432b694168266b1e1510f6e806089bc/src/lib.rs#L125), this PR adds reflection info for other shader stages. This is useful for mesh/amplification shaders, because Metal needs to know the number of thread groups to spawn as well as `needs_draw_params`, which can be used in conjunction with https://github.com/Traverse-Research/saxaboom/pull/37

And because there are a lot of shader stages, it's quite tedious to write same variation of "Info" structure for every single one, so I added a macro.