### PR TITLE
runtime: Fix and require compatibility with `objc2-metal 0.3.2`

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,15 +22,16 @@ targets = [
 
 [dependencies]
 objc2 = { version = "0.6", default-features = false }
-objc2-metal = { version = "0.3", default-features = false, features = [
-  "std",
+objc2-metal = { version = "0.3.2", default-features = false, features = [
   "MTLAllocation",
   "MTLBuffer",
   "MTLCommandEncoder",
+  "MTLGPUAddress",
   "MTLRenderCommandEncoder",
   "MTLResource",
   "MTLSampler",
   "MTLStageInputOutputDescriptor",
   "MTLTexture",
   "MTLTypes",
+  "std",
 ] }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -63,7 +63,7 @@ impl ffi::IRDescriptorTableEntry {
         Self {
             gpuVA: buffer_view.buffer.gpuAddress() + buffer_view.buffer_offset,
             textureViewID: match buffer_view.texture_buffer_view {
-                Some(texture) => unsafe { texture.gpuResourceID() }.to_raw(),
+                Some(texture) => texture.gpuResourceID().to_raw(),
                 None => 0,
             },
             metadata: Self::buffer_metadata(buffer_view),
@@ -79,7 +79,7 @@ impl ffi::IRDescriptorTableEntry {
         const METADATA: u32 = 0; // According to the current docs, the metadata must be 0
         Self {
             gpuVA: 0,
-            textureViewID: unsafe { argument.gpuResourceID() }.to_raw(),
+            textureViewID: argument.gpuResourceID().to_raw(),
             metadata: min_lod_clamp.to_bits() as u64 | ((METADATA as u64) << 32),
         }
     }
@@ -91,7 +91,7 @@ impl ffi::IRDescriptorTableEntry {
     #[doc(alias = "IRDescriptorTableSetSampler")]
     pub fn sampler(argument: &ProtocolObject<dyn MTLSamplerState>, lod_bias: f32) -> Self {
         Self {
-            gpuVA: unsafe { argument.gpuResourceID() }.to_raw(),
+            gpuVA: argument.gpuResourceID().to_raw(),
             textureViewID: 0,
             metadata: lod_bias.to_bits() as u64,
         }


### PR DESCRIPTION
Technically a breaking change, `.gpuAddress()` is now behind a new `MTLGPUAddress` crate feature that didn't exist on `0.3.1` yet, requiring us to add the flag and bump the minimum version bound to `0.3.2`.

Alternatively downstream crates depend on `objc2-metal 0.3.2` with the `MTLGPUAddress` feature that enables it to be used here, which is why we didn't notice it yet.

CC @madsmtm
